### PR TITLE
fix(lidar): fix the launch issue for vanjeelidar

### DIFF
--- a/modules/drivers/lidar/vanjeelidar/BUILD
+++ b/modules/drivers/lidar/vanjeelidar/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "//modules/drivers/lidar/vanjeelidar/proto:vanjeelidar_config_cc_proto",
         "@vanjee_driver",
     ],
+    alwayslink = True,
 )
 
 cpplint()

--- a/modules/drivers/lidar/vanjeelidar/dag/vanjeelidar.dag
+++ b/modules/drivers/lidar/vanjeelidar/dag/vanjeelidar.dag
@@ -1,5 +1,5 @@
 module_config {
-    module_library : "modules/drivers/lidar/vanjeelidar/libvanjeelidar_component.so"
+    module_library : "/apollo/bazel-bin/modules/drivers/lidar/vanjeelidar/libvanjeelidar_component.so"
     components {
         class_name : "VanjeelidarComponent"
         config {


### PR DESCRIPTION
- correct component library path
- ensure all symbols linked to the component library