### PR TITLE
fix(build): fix segmentation fault issue on aarch64

### DIFF
--- a/scripts/apollo_build.sh
+++ b/scripts/apollo_build.sh
@@ -248,7 +248,7 @@ function run_bazel_build() {
   info "${TAB}Disabled:      ${YELLOW}${disabled_targets}${NO_COLOR}"
 
   if [[ "$(uname -m)" == "aarch64" ]]; then
-    local job_args="--copt=-march=native --host_copt=-march=native --jobs=$(nproc) --local_ram_resources=HOST_RAM*0.7"
+    local job_args="--copt=-march=native --host_copt=-march=native --jobs=$(nproc) --local_ram_resources=HOST_RAM*0.7 --copt=-fPIC --host_copt=-fPIC"
   else
     # x64
     local job_args="--copt=-mavx2 --host_copt=-mavx2 --jobs=$(nproc) --local_ram_resources=HOST_RAM*0.7"


### PR DESCRIPTION
- enable `-fPIC` compile flag on aarch64 to avoid `SIGSEGV` issue, code based on absolute addresses may be generated in opt mode